### PR TITLE
Fixed link to draft 5 and 4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ Compatibility
 Drafts **3**, **4**, and **5**.
 
 This version conforms to `JSON Hypermedia API Language Internet Draft 5
-<http://tools.ietf.org/html/draft-kelly-json-hal-04>`_,
+<http://tools.ietf.org/html/draft-kelly-json-hal-05>`_,
 but it can also work with JSON from
-`Draft 4 <http://tools.ietf.org/html/draft-kelly-json-hal-03>`_ and
+`Draft 4 <http://tools.ietf.org/html/draft-kelly-json-hal-04>`_ and
 `Draft 3 <http://tools.ietf.org/html/draft-kelly-json-hal-03>`_.
 The draft version can be explicitly selected when the document is constructed,
 but the default behavior is for documents to automatically detect which draft


### PR DESCRIPTION
The current README links draft 5 accidently to draft 4, same goes for draft 4 which links to draft 3. It's just a small fix ;)
